### PR TITLE
Versioning update

### DIFF
--- a/src/Nerdbank.MSBuildExtension/Nerdbank.MSBuildExtension.csproj
+++ b/src/Nerdbank.MSBuildExtension/Nerdbank.MSBuildExtension.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.25" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' ">
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3" />

--- a/src/test.ps1
+++ b/src/test.ps1
@@ -37,7 +37,7 @@ Remove-Item -rec "$env:userprofile\.nuget\packages\Nerdbank.MSBuildExtension" -E
 Remove-Item -rec "$env:userprofile\.nuget\packages\SampleExtension" -ErrorAction SilentlyContinue
 Remove-Item -rec "$env:userprofile\.nuget\packages\ComplexExtension" -ErrorAction SilentlyContinue
 
-$versionInfo = & "$env:userprofile\.nuget\packages\Nerdbank.GitVersioning\1.6.25\tools\Get-Version.ps1" -ProjectDirectory $PSScriptRoot
+$versionInfo = & "$env:userprofile\.nuget\packages\Nerdbank.GitVersioning\2.1.23\tools\Get-Version.ps1" -ProjectDirectory $PSScriptRoot
 $dogfoodPackageVersion = $versionInfo.NuGetPackageVersion
 
 function PackExtension($extensionProjectPath) {


### PR DESCRIPTION
Old `Nerdbank.GitVersioning` package cause failure in depended packages, see https://github.com/AArnott/CodeGeneration.Roslyn/issues/68 .